### PR TITLE
Add simplified generator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,11 @@ Packet level
 
 We sample a cluster identified in the latent space thanks to the GMM (Gaussian Mixture Model) and we use the VAE (Variational AutoEncoder) model decoder to reconstruct the parameters of the packet. The following scripts, in the folder ``scripts/modeling/packet/inference/``, are used:  
 
-* ``script_packet_generation.py``: shows how to generate a packet with the GMM (Gaussian Mixture Model) and the VAE (Variational Auto-Encoder).  
+* ``script_packet_generation.py``: shows how to generate a packet with the GMM (Gaussian Mixture Model) and the VAE (Variational Auto-Encoder).
+* ``generate_payload_time.py``: generate only ``payload_length`` and ``time_diff`` features
+  from the pretrained models. The script expects a CSV file containing a
+  ``flow_id`` column which determines how many flows and packets should be
+  created.
 
 
 Flow level

--- a/scripts/generation/generate_payload_time.py
+++ b/scripts/generation/generate_payload_time.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Generate payload_length and time_diff using pretrained NeCSTGen models.
+
+This helper loads the pretrained VAE and GMM models and generates packets for
+each flow present in the input CSV. Only ``payload_length`` and ``time_diff``
+features are saved in the output.
+"""
+
+import argparse
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+import joblib
+
+
+def load_models(proto: str, models_dir: str):
+    """Load VAE encoder/decoder and GMM for a protocol."""
+    enc = tf.keras.models.load_model(
+        f"{models_dir}/VAE/encoder_vae_MONDAY_T11_{proto}_FINAL.h5",
+        custom_objects={"LeakyReLU": tf.keras.layers.LeakyReLU},
+    )
+    dec = tf.keras.models.load_model(
+        f"{models_dir}/VAE/decoder_vae_MONDAY_T11_{proto}_FINAL.h5",
+        custom_objects={"LeakyReLU": tf.keras.layers.LeakyReLU},
+    )
+    gmm = joblib.load(
+        f"{models_dir}/GMM/gmm_MONDAY_BL100_T11_{proto}_FLOWS_FINAL.sav"
+    )
+    return enc, dec, gmm
+
+
+FEATURES = {
+    "HTTP": [
+        "layers_2",
+        "layers_3",
+        "layers_4",
+        "layers_5",
+        "flags",
+        "sport",
+        "dport",
+        "length_total",
+        "time_diff",
+        "rate",
+        "rolling_rate_byte_sec",
+        "rolling_rate_byte_min",
+        "rolling_rate_packet_sec",
+        "rolling_rate_packet_min",
+        "header_length",
+        "payload_length",
+    ],
+    "UDP_GOOGLE_HOME": [
+        "layers_2",
+        "layers_3",
+        "layers_4",
+        "layers_5",
+        "length_total",
+        "time_diff",
+        "rate",
+        "rolling_rate_byte_sec",
+        "rolling_rate_byte_min",
+        "rolling_rate_packet_sec",
+        "rolling_rate_packet_min",
+        "header_length",
+        "payload_length",
+    ],
+}
+
+# indexes of features in processed data
+IDX_TIME_DIFF = {"HTTP": 8, "UDP_GOOGLE_HOME": 5}
+IDX_PAYLOAD = {"HTTP": 15, "UDP_GOOGLE_HOME": 12}
+
+
+def scale_back(x: np.ndarray, col: str, df_raw: pd.DataFrame) -> np.ndarray:
+    """Reverse the normalization applied during training."""
+    scaled = x * (df_raw[col].max() - df_raw[col].min()) + df_raw[col].min()
+    return np.power(10, scaled)
+
+
+def generate_packets(dec, gmm, n_packets: int) -> np.ndarray:
+    """Sample latent vectors from the GMM and decode packets."""
+    z, _ = gmm.sample(n_packets)
+    return dec.predict(z)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate packet features")
+    parser.add_argument("--protocol", choices=["HTTP", "UDP_GOOGLE_HOME"], required=True)
+    parser.add_argument("--input", help="CSV file containing a flow_id column", required=True)
+    parser.add_argument("--output", help="Path to save generated CSV", required=True)
+    parser.add_argument("--models-dir", default="models", help="Directory with pretrained models")
+    args = parser.parse_args()
+
+    enc, dec, gmm = load_models(args.protocol, args.models_dir)
+
+    df_counts = pd.read_csv(args.input)
+    if "flow_id" not in df_counts.columns:
+        raise ValueError("input file must contain a flow_id column")
+    flow_sizes = df_counts.groupby("flow_id").size()
+
+    df_raw = pd.read_csv(f"data/raw/df_raw_{args.protocol}.csv")
+
+    results = []
+    for fid, count in flow_sizes.items():
+        feats = generate_packets(dec, gmm, int(count))
+        cols = FEATURES[args.protocol]
+        df_feat = pd.DataFrame(feats, columns=cols)
+        payl = scale_back(df_feat.iloc[:, IDX_PAYLOAD[args.protocol]].to_numpy(), "payload_length", df_raw)
+        time = scale_back(df_feat.iloc[:, IDX_TIME_DIFF[args.protocol]].to_numpy(), "time_diff", df_raw)
+        tmp = pd.DataFrame({"flow_id": fid, "payload_length": payl, "time_diff": time})
+        results.append(tmp)
+
+    pd.concat(results, ignore_index=True).to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script to generate `payload_length` and `time_diff` from pretrained models
- document the new script in the README

## Testing
- `python -m py_compile scripts/generation/generate_payload_time.py`

------
https://chatgpt.com/codex/tasks/task_e_688734190b2c8324a6adef6243f3c5bf