### PR TITLE
Fix scale_back usage in payload/time generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,9 @@ We sample a cluster identified in the latent space thanks to the GMM (Gaussian M
 
 * ``script_packet_generation.py``: shows how to generate a packet with the GMM (Gaussian Mixture Model) and the VAE (Variational Auto-Encoder).
 * ``generate_payload_time.py``: generate only ``payload_length`` and ``time_diff`` features
-  from the pretrained models. The script expects a CSV file containing a
+  from the pretrained models. ``payload_length`` is rescaled linearly while
+  ``time_diff`` is decoded using an additional ``log10`` exponentiation to
+  restore the original time scale. The script expects a CSV file containing a
   ``flow_id`` column which determines how many flows and packets should be
   created.
 


### PR DESCRIPTION
## Summary
- update `scale_back` to support optional log scaling
- decode payload_length linearly and time_diff with log scaling
- clarify how time_diff is rescaled in README

## Testing
- `python -m py_compile scripts/generation/generate_payload_time.py`

------
https://chatgpt.com/codex/tasks/task_e_68875bdabc3c8324903ace5679af62db