### PR TITLE
Fix time diff log rescaling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,8 +114,9 @@ We sample a cluster identified in the latent space thanks to the GMM (Gaussian M
 * ``script_packet_generation.py``: shows how to generate a packet with the GMM (Gaussian Mixture Model) and the VAE (Variational Auto-Encoder).
 * ``generate_payload_time.py``: generate only ``payload_length`` and ``time_diff`` features
   from the pretrained models. ``payload_length`` is rescaled linearly while
-  ``time_diff`` is decoded using an additional ``log10`` exponentiation to
-  restore the original time scale. The script expects a CSV file containing a
+  ``time_diff`` is decoded using a ``log10`` exponentiation. The scaling range for
+  ``time_diff`` is taken from the ``log10`` values of the raw data before the
+  exponentiation restores the original time scale. The script expects a CSV file containing a
   ``flow_id`` column which determines how many flows and packets should be
   created.
 

--- a/scripts/generation/generate_payload_time.py
+++ b/scripts/generation/generate_payload_time.py
@@ -88,7 +88,8 @@ def scale_back(
         undo the log10 transform used during training. Defaults to ``False``.
     """
 
-    scaled = x * (df_raw[col].max() - df_raw[col].min()) + df_raw[col].min()
+    col_data = np.log10(df_raw[col]) if log_scale else df_raw[col]
+    scaled = x * (col_data.max() - col_data.min()) + col_data.min()
     return np.power(10, scaled) if log_scale else scaled
 
 


### PR DESCRIPTION
## Summary
- adjust log10 scaling in `scale_back`
- document time diff scaling in README

## Testing
- `python -m py_compile scripts/generation/generate_payload_time.py`

------
https://chatgpt.com/codex/tasks/task_e_68875f01f3bc832490c47e54ec433749